### PR TITLE
Add switch monster option on enemy monster downed

### DIFF
--- a/Assets/Game/UI/HUD.prefab
+++ b/Assets/Game/UI/HUD.prefab
@@ -535,7 +535,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 11, y: -4}
+  m_AnchoredPosition: {x: 11.3, y: -5}
   m_SizeDelta: {x: 17.195007, y: 20.78}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4952771028596814483
@@ -568,7 +568,7 @@ MonoBehaviour:
       m_Calls: []
   m_FontData:
     m_Font: {fileID: 12800000, guid: 147d7fbc1838f664e9450afb00c81ef8, type: 3}
-    m_FontSize: 14
+    m_FontSize: 12
     m_FontStyle: 0
     m_BestFit: 0
     m_MinSize: 1

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -1825,9 +1825,9 @@ RectTransform:
   - {fileID: 1978073286}
   - {fileID: 1799665710}
   - {fileID: 1083146082}
-  - {fileID: 2146497621}
   - {fileID: 1279435894}
   - {fileID: 1038869538}
+  - {fileID: 2146497621}
   - {fileID: 316494952}
   m_Father: {fileID: 1338626719}
   m_RootOrder: 1
@@ -3811,7 +3811,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4952771027540613290, guid: 466a64f1e5f22f14fa633af3f649e694, type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 4952771027540613290, guid: 466a64f1e5f22f14fa633af3f649e694, type: 3}
       propertyPath: m_AnchorMax.x
@@ -3867,11 +3867,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4952771027540613290, guid: 466a64f1e5f22f14fa633af3f649e694, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -273
+      value: 268.1
       objectReference: {fileID: 0}
     - target: {fileID: 4952771027540613290, guid: 466a64f1e5f22f14fa633af3f649e694, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 142.8
+      value: -62.6
       objectReference: {fileID: 0}
     - target: {fileID: 4952771027540613290, guid: 466a64f1e5f22f14fa633af3f649e694, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -3981,8 +3981,8 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: Testing the dialog. Does it truncate or wrap? What happens at the second
-    line?
+  m_Text: If you're seeing this, something went terribly wrong. Please notify the
+    developer.
 --- !u!222 &1048519239
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -3990,6 +3990,85 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1048519236}
+  m_CullTransparentMesh: 1
+--- !u!1 &1053231811
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1053231812}
+  - component: {fileID: 1053231814}
+  - component: {fileID: 1053231813}
+  m_Layer: 0
+  m_Name: YesText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1053231812
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1053231811}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.9998544, y: 0.9998544, z: 0.9998544}
+  m_Children: []
+  m_Father: {fileID: 1199434708}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.000088692, y: 22.951}
+  m_SizeDelta: {x: 100.01, y: 54.105}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1053231813
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1053231811}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 147d7fbc1838f664e9450afb00c81ef8, type: 3}
+    m_FontSize: 28
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Yes
+--- !u!222 &1053231814
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1053231811}
   m_CullTransparentMesh: 1
 --- !u!1 &1083146081
 GameObject:
@@ -4167,6 +4246,83 @@ RectTransform:
   m_AnchoredPosition: {x: 280.48, y: -4.7225}
   m_SizeDelta: {x: 225.25, y: 90.555}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1199434707
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1199434708}
+  - component: {fileID: 1199434710}
+  - component: {fileID: 1199434709}
+  m_Layer: 0
+  m_Name: ChoiceSelector
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1199434708
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1199434707}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1053231812}
+  - {fileID: 1417318987}
+  m_Father: {fileID: 2146497621}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 329.4, y: 90.6}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1199434709
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1199434707}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 2666c666a9e34054dad8c648df05bc07, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1199434710
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1199434707}
+  m_CullTransparentMesh: 1
 --- !u!1 &1203110217
 GameObject:
   m_ObjectHideFlags: 0
@@ -5386,6 +5542,85 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1404901494}
+  m_CullTransparentMesh: 1
+--- !u!1 &1417318986
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1417318987}
+  - component: {fileID: 1417318989}
+  - component: {fileID: 1417318988}
+  m_Layer: 0
+  m_Name: NoText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1417318987
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1417318986}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.9998544, y: 0.9998544, z: 0.9998544}
+  m_Children: []
+  m_Father: {fileID: 1199434708}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.000088692, y: -27.051}
+  m_SizeDelta: {x: 100.01, y: 45.905}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1417318988
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1417318986}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 147d7fbc1838f664e9450afb00c81ef8, type: 3}
+    m_FontSize: 28
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: No
+--- !u!222 &1417318989
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1417318986}
   m_CullTransparentMesh: 1
 --- !u!1 &1759826123
 GameObject:
@@ -22842,8 +23077,9 @@ RectTransform:
   - {fileID: 1115468091}
   - {fileID: 961951022}
   - {fileID: 1121408181}
+  - {fileID: 1199434708}
   m_Father: {fileID: 513852345}
-  m_RootOrder: 5
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -22905,8 +23141,11 @@ MonoBehaviour:
   dialogText: {fileID: 1048519238}
   energyText: {fileID: 826292834}
   typeText: {fileID: 25413377}
+  yesText: {fileID: 1053231813}
+  noText: {fileID: 1417318988}
   actionSelector: {fileID: 1115468090}
   moveSelector: {fileID: 961951021}
+  choiceSelector: {fileID: 1199434707}
   moveDetails: {fileID: 1121408180}
   actionTexts:
   - {fileID: 149434795}
@@ -23049,7 +23288,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4952771027540613290, guid: 466a64f1e5f22f14fa633af3f649e694, type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 4952771027540613290, guid: 466a64f1e5f22f14fa633af3f649e694, type: 3}
       propertyPath: m_AnchorMax.x
@@ -23105,11 +23344,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4952771027540613290, guid: 466a64f1e5f22f14fa633af3f649e694, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 277.7
+      value: -272.1
       objectReference: {fileID: 0}
     - target: {fileID: 4952771027540613290, guid: 466a64f1e5f22f14fa633af3f649e694, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -67.4
+      value: 139.8
       objectReference: {fileID: 0}
     - target: {fileID: 4952771027540613290, guid: 466a64f1e5f22f14fa633af3f649e694, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x

--- a/Assets/Scripts/Battle/BattleDialogBox.cs
+++ b/Assets/Scripts/Battle/BattleDialogBox.cs
@@ -10,9 +10,12 @@ public class BattleDialogBox : MonoBehaviour
     [SerializeField] Text dialogText;
     [SerializeField] Text energyText;
     [SerializeField] Text typeText;
+    [SerializeField] Text yesText;
+    [SerializeField] Text noText;
 
     [SerializeField] GameObject actionSelector;
     [SerializeField] GameObject moveSelector;
+    [SerializeField] GameObject choiceSelector;
     [SerializeField] GameObject moveDetails;
     [SerializeField] List<Text> actionTexts;
     [SerializeField] List<Text> moveTexts;
@@ -62,6 +65,21 @@ public class BattleDialogBox : MonoBehaviour
             energyText.color = Color.black;
     }
 
+    public void UpdateChoiceSelection(bool yes)
+    {
+        if (yes)
+        {
+            yesText.color = highlightColor;
+            noText.color = Color.black;
+        }
+        else
+        {
+            noText.color = highlightColor;
+            yesText.color = Color.black;
+        }
+            
+    }
+
     //
     // HELPER FUNCTIONS
     //
@@ -95,5 +113,10 @@ public class BattleDialogBox : MonoBehaviour
     {
         moveSelector.SetActive(enabled);
         moveDetails.SetActive(enabled);
+    }
+
+    public void EnableChoiceSelector(bool enabled)
+    {
+        choiceSelector.SetActive(enabled);
     }
 }

--- a/Assets/Scripts/Battle/BattleState.cs
+++ b/Assets/Scripts/Battle/BattleState.cs
@@ -4,6 +4,7 @@ public enum BattleState
     Busy,
     ActionSelection,
     MoveSelection,
+    ChoiceSelection,
     ExecutingTurn,
     BattleOver,
     PartyScreen

--- a/Assets/Scripts/Character/BattlerController.cs
+++ b/Assets/Scripts/Character/BattlerController.cs
@@ -32,6 +32,11 @@ public class BattlerController : MonoBehaviour, Interactable
         RotateLoS(character.Animator.DefaultDirection);
     }
 
+    private void Update()
+    {
+        character.HandleUpdate();
+    }
+
     public void Interact(Transform interactChar)
     {
         character.TurnToInteract(interactChar.position);

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -127,7 +127,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 1.0.4
+  bundleVersion: 1.0.5
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0


### PR DESCRIPTION


# Description

*Allow player to switch freely after downing enemy monster
**Fix no animation bug on battle encounter
**Swap player and enemy HUD locations
**Adjust HUD HP label text size
**Upgrade project to 1.0.5

Fixes #97

## Type of change



- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Manually

**Test Configuration**:
* Build No: 1.0.4
* OS: W10

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
