### PR TITLE
Fix exception after char battle bug

### DIFF
--- a/Assets/Ravar/Gameplay/Monsters/Firefly.asset
+++ b/Assets/Ravar/Gameplay/Monsters/Firefly.asset
@@ -22,7 +22,7 @@ MonoBehaviour:
   spAttack: 60
   spDefense: 50
   speed: 65
-  expGiven: 300
+  expGiven: 65
   catchRate: 255
   leftSprite: {fileID: 21300000, guid: 68c207a65d38c564399b6dcaf0ca1997, type: 3}
   rightSprite: {fileID: 21300000, guid: 2c80f11eee061744cb77d876367f85fc, type: 3}

--- a/Assets/Ravar/Gameplay/Monsters/Tortoad.asset
+++ b/Assets/Ravar/Gameplay/Monsters/Tortoad.asset
@@ -22,7 +22,7 @@ MonoBehaviour:
   spAttack: 50
   spDefense: 64
   speed: 43
-  expGiven: 300
+  expGiven: 65
   catchRate: 255
   leftSprite: {fileID: 21300000, guid: 71ec3ea6a39751f45a69898fa778f240, type: 3}
   rightSprite: {fileID: 21300000, guid: aec368220e450a042ba3361dda2a5fb4, type: 3}

--- a/Assets/Ravar/Gameplay/Monsters/Wabbi.asset
+++ b/Assets/Ravar/Gameplay/Monsters/Wabbi.asset
@@ -21,7 +21,7 @@ MonoBehaviour:
   spAttack: 65
   spDefense: 65
   speed: 45
-  expGiven: 300
+  expGiven: 65
   catchRate: 255
   leftSprite: {fileID: 21300000, guid: 1244abe4a992a6346a9cda5e98ea24c2, type: 3}
   rightSprite: {fileID: 21300000, guid: 89a6e783370c2544a824fe67bc066782, type: 3}

--- a/Assets/Ravar/Scripts/Battle/BattleSystem.cs
+++ b/Assets/Ravar/Scripts/Battle/BattleSystem.cs
@@ -48,6 +48,7 @@ namespace Itsdits.Ravar.Battle
         {
             this.playerParty = playerParty;
             this.wildMonster = wildMonster;
+            isCharBattle = false;
             player = playerParty.GetComponent<PlayerController>();
             StartCoroutine(SetupBattle());
         }


### PR DESCRIPTION
# Description

Set `isCharBattle` to false at the beginning of wild encounters

Fixes #107 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Manually

**Test Configuration**:
* Build No: 1.0.5
* OS: W10

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
