### PR TITLE
Fix pause menu showing on scene switch

### DIFF
--- a/Assets/Ravar/Scripts/GameController.cs
+++ b/Assets/Ravar/Scripts/GameController.cs
@@ -140,6 +140,23 @@ namespace Itsdits.Ravar
                 state = prevState;
             }
         }
+
+        /// <summary>
+        /// Stops the character and prevents player input. Used in scene switching and cutscenes.
+        /// </summary>
+        /// <param name="frozen">Is the player frozen or not.</param>
+        public void FreezePlayer(bool frozen)
+        {
+            if (frozen)
+            {
+                prevState = state;
+                state = GameState.Cutscene;
+            }
+            else
+            {
+                state = prevState;
+            }
+        }
              
         /// <summary>
         /// Sets the GameState to World, used to release player from error conditions, etc.

--- a/Assets/Ravar/Scripts/Levels/Portal.cs
+++ b/Assets/Ravar/Scripts/Levels/Portal.cs
@@ -32,13 +32,13 @@ namespace Itsdits.Ravar.Levels
         private IEnumerator SwitchScene() 
         {
             DontDestroyOnLoad(gameObject);
-            GameController.Instance.PauseGame(true);
+            GameController.Instance.FreezePlayer(true);
 
             yield return SceneManager.LoadSceneAsync(sceneToLoad);
             var destination = FindObjectsOfType<Portal>().First(x => x != this && x.portalId == this.portalId);
             player.SetOffsetOnTile(destination.SpawnPoint.position);
 
-            GameController.Instance.PauseGame(false);
+            GameController.Instance.FreezePlayer(false);
             Destroy(gameObject);
         }
     }


### PR DESCRIPTION
# Description

Changed the `SwitchScene()` function to call a new `FreezePlayer()` function instead of `PauseGame()`.

Fixes #142

## Type of change



- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Manually

**Test Configuration**:
* Build No: 1.0.7
* OS: W10

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
