### PR TITLE
Fix pause menu breaking dialog box

### DIFF
--- a/Assets/Ravar/Resources/Core/CorePack.prefab
+++ b/Assets/Ravar/Resources/Core/CorePack.prefab
@@ -296,7 +296,7 @@ GameObject:
   - component: {fileID: 6249827043630627062}
   - component: {fileID: 1141818895532616907}
   - component: {fileID: 1567204535703246892}
-  m_Layer: 0
+  m_Layer: 5
   m_Name: Pause
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -342,7 +342,7 @@ Canvas:
   m_SortingBucketNormalizedSize: 0
   m_AdditionalShaderChannelsFlag: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 1
   m_TargetDisplay: 0
 --- !u!114 &6249827043630627062
 MonoBehaviour:


### PR DESCRIPTION


# Description

Changed sorting layer of pause menu to fix overlap. This also seemed to fix the issue of the dialog box not regaining control of player input after the menu was closed.

Fixes #144 

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Manually

**Test Configuration**:
* Build No: 1.0.7
* OS: W10

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
